### PR TITLE
add stage_duration_seconds metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,36 +2,55 @@
 
 An exporter for Jenkins Build metrics written in Golang.
 The program is intended to run as daemon.
-It fetches periodically metrics for Jenkins build via the Jenkins API and
-publishes them via an HTTP endpoint in Prometheus format.
+It fetches periodically metrics for Jenkins builds and Stages via the Jenkins
+API and publishes them via an HTTP endpoint in Prometheus format.
 
 It provides the following Prometheus metrics:
 
-- Histogram:
-  `jenkins_exporter_job_duration_seconds_bucket`,  
-  `jenkins_exporter_job_duration_seconds_sum`,  
-  `jenkins_exporter_job_duration_seconds_count`  
-  - Labels:
-    - result
-    - jenkins_job: the name of the Jenkins Job
+- Histograms:
+  - `jenkins_exporter_job_duration_seconds_bucket`,  
+    `jenkins_exporter_job_duration_seconds_sum`,  
+    `jenkins_exporter_job_duration_seconds_count`  
+    - Labels:
+      - result
+      - jenkins_job: the name of the Jenkins Job
     - type: type of recorded duration, one of:
       - blocked_time
       - buildable_time
       - building_duration
       - executing_time
       - waiting_time
+  - `jenkins_exporter_stage_duration_seconds_bucket`,  
+    `jenkins_exporter_stage_duration_seconds_sum`,  
+    `jenkins_exporter_stage_duration_seconds_count`,  
+    - Labels:
+      - result: result of the stage
+      - stage: stage name
+      - type:
+        - duration
 - Counter:
   `jenkins_exporter_errors`  
   Counts the number of errors the jenkins-exporter encountered when fetching
   informations from the Jenkins API.
   - type:
     - jenkins_api
+    - jenkins_wfapi
 
-By default metrics are recorded for every finished Jenkins build. The Jenkins
-jobs for that builds are recorded can be limited with the
+By default job metrics are recorded for every finished Jenkins build. The
+Jenkins jobs for that builds are recorded can be limited with the
 `--jenkins-job-whitelist` command-line parameter.
 The duration types that are recorded can also be configured via a commandline
 parameter.
+
+The exporter can also record durations of individual pipeline stages. This
+requires that the
+[Pipeline Stage View Plugin](https://plugins.jenkins.io/pipeline-rest-api/) is
+installed on the Jenkins server. Recording per stage metrics can be enabled via the
+`-enable-build-stage-metrics` command-line parameter. The
+`-build-stage-allowlist` parameter allows to specify for which jobs and stages,
+per-stage metrics are recorded.
+
+All parameter can also be specified via environment variables.
 See `./jenkins-exporter -help` for more information.
 
 ## Installation ##

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -66,3 +66,52 @@ func (u *Float64Slice) Set(v string) error {
 
 	return nil
 }
+
+// BuildStageMapFlag parses a a string in the format:
+// "<JOB-NAME>:<STAGE-NAME>,..."
+// into a map[JOB-NAME]map[STAGE-NAME]struct{} datastructure.
+// If an elem ends with a "," it is interpreted as being on the Job-Name.
+// Later elemens overwrite earlier elements.
+type BuildStageMapFlag map[string]map[string]struct{}
+
+func (b BuildStageMapFlag) Set(v string) error {
+	for _, elem := range strings.Split(v, ",") {
+		idx := strings.LastIndex(elem, ":")
+		if idx == -1 || len(elem) == idx+1 {
+			b[elem] = map[string]struct{}{}
+			continue
+		}
+
+		job := elem[:idx]
+		stage := elem[idx+1:]
+		if m, exists := b[job]; exists {
+			m[stage] = struct{}{}
+			continue
+		}
+
+		b[job] = map[string]struct{}{stage: {}}
+	}
+
+	return nil
+}
+
+func (b BuildStageMapFlag) String() string {
+	res := strings.Builder{}
+
+	for job, stageMap := range b {
+		if len(stageMap) == 0 {
+			res.WriteString(job)
+			res.WriteRune(',')
+			continue
+		}
+		for stage := range stageMap {
+			res.WriteString(job)
+			res.WriteRune(':')
+			res.WriteString(stage)
+			res.WriteRune(',')
+		}
+	}
+
+	return strings.TrimRight(res.String(), ",")
+
+}

--- a/internal/jenkins/stages.go
+++ b/internal/jenkins/stages.go
@@ -1,0 +1,64 @@
+package jenkins
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type respWFAPIRaw struct {
+	Stages []*respWFAPIStageRaw `json:"stages"`
+}
+
+type respWFAPIStageRaw struct {
+	Name           string `json:"name"`
+	Status         string `json:"status"`
+	DurationMillis int64  `json:"durationMillis"`
+}
+
+type Stage struct {
+	Name     string
+	Status   string
+	Duration time.Duration
+}
+
+func respWFAPIRawToStage(raw *respWFAPIStageRaw) *Stage {
+	return &Stage{
+		Name:     raw.Name,
+		Status:   raw.Status,
+		Duration: time.Duration(raw.DurationMillis) * time.Millisecond,
+	}
+}
+
+func respWFAPIRawToStages(resp *respWFAPIRaw) []*Stage {
+	res := make([]*Stage, len(resp.Stages))
+	for i, stage := range resp.Stages {
+		res[i] = respWFAPIRawToStage(stage)
+	}
+	return res
+}
+
+func (c *Client) wfapiJobBuildURL(jobName, multibranchJobName, buildID string) (string, error) {
+	if multibranchJobName == "" {
+		return url.JoinPath(c.serverURL, "job", jobName, buildID, "wfapi")
+	}
+
+	return url.JoinPath(c.serverURL, "job", multibranchJobName, "job", jobName, buildID, "wfapi")
+}
+
+func (c *Client) Stages(jobName, multibranchJobName string, buildID int64) ([]*Stage, error) {
+	var resp respWFAPIRaw
+
+	wfapiURL, err := c.wfapiJobBuildURL(jobName, multibranchJobName, fmt.Sprint(buildID))
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.do(http.MethodGet, wfapiURL, &resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return respWFAPIRawToStages(&resp), nil
+}

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -47,27 +47,6 @@ func (c *Collector) CounterAdd(key string, cnt float64, help string, labels map[
 	s.With(labels).Add(cnt)
 }
 
-func (c *Collector) Summary(key string, val float64, help string, labels map[string]string) {
-	s, exist := c.summaries[key]
-	if !exist {
-		s = prometheus.NewSummaryVec(
-			prometheus.SummaryOpts{
-				Namespace:   c.namespace,
-				Name:        sanitize(key),
-				ConstLabels: c.constLabels,
-				Help:        help,
-			},
-			labelNames(labels),
-		)
-
-		prometheus.MustRegister(s)
-
-		c.summaries[key] = s
-	}
-
-	s.With(labels).Observe(val)
-}
-
 func (c *Collector) Histogram(key string, val float64, help string, buckets []float64, labels map[string]string) {
 	h, exist := c.histograms[key]
 	if !exist {


### PR DESCRIPTION
add stage_duration_seconds metric

Add a new histogram metric that record per stage durations of builds.
The metrics are retrieved from Jenkins wfapi endpoint. They are not available
via /api/. This means per jenkins build an additional API request needs to be
done.
The metric is called jenkins_exporter_stage_duration_seconds.
It has the labels result, name and type.

Recording per stage metrics are enabled by default.
They can be disabled via the '-enable-build-stage-metric' parameter.
The new '-build-stage-allowlist' parameter allows to specify stages for jobs
for that the metrics is record.
With the parameter '-build-stage-ignore-unsuccessful' it can be controlled if
only metrics for stages with a SUCCESS result are recorded.

Example of the new metric:
jenkins_exporter_stage_duration_seconds_bucket{jenkins_job="integrationtests",result="success",stage="Create Sandbox",type="duration",le="60"} 0
jenkins_exporter_stage_duration_seconds_bucket{jenkins_job="sisu-qa-integrationtests-eu",result="success",stage="Create Sandbox",type="duration",le="300"} 0