### PR TITLE
golangci-lint: add custom config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+run:
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - errcheck
+    - exportloopref
+    - gocritic
+    - goimports
+    - goprintffuncname
+    - gosimple
+    - ineffassign
+    - misspell
+    - nolintlint
+    - prealloc
+    - revive
+    - staticcheck
+    - tenv
+    - typecheck
+    - unconvert
+    - unused
+    - usestdlibvars
+    - vet
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/simplesurance/jenkins-exporter

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ const (
 )
 
 // Version is set during compiliation via -ldflags.
-var Version string = "unknown"
+var Version = "unknown"
 
 const stateStoreCleanupInterval = 10 * 60 * time.Second
 


### PR DESCRIPTION
Add a custom golangci-lint config that enables more linters then the default Also fix the one issue that was found by revive.