### PR TITLE
do not record runtime metrics for builds that are still running

### DIFF
--- a/internal/jenkins/builds.go
+++ b/internal/jenkins/builds.go
@@ -47,6 +47,17 @@ type Build struct {
 	Building           bool
 }
 
+func (b *Build) FullJobName() string {
+	if b.MultiBranchJobName != "" {
+		return b.MultiBranchJobName + "/" + b.JobName
+	}
+	return b.JobName
+}
+
+func (b *Build) String() string {
+	return b.FullJobName() + " #" + fmt.Sprint(b.ID)
+}
+
 func (b *buildRawResp) validate() error {
 	if b.Building == nil {
 		return errors.New("Building field is missing (nil)")

--- a/internal/jenkins/builds.go
+++ b/internal/jenkins/builds.go
@@ -98,7 +98,7 @@ func multibranchBuildID(multibranchJob, job *jobRawResp, build *buildRawResp) st
 	return fmt.Sprintf("%s/%s/%s", multibranchJob.Name, job.Name, build.ID)
 }
 
-func (c *Client) respRawToBuilds(raw *respRaw, removeBuildingBuilds bool) []*Build {
+func (c *Client) respRawToBuilds(raw *respRaw) []*Build {
 	var res []*Build
 
 	for _, job := range raw.Jobs {
@@ -108,7 +108,7 @@ func (c *Client) respRawToBuilds(raw *respRaw, removeBuildingBuilds bool) []*Bui
 				continue
 			}
 
-			if removeBuildingBuilds && *rawBuild.Building {
+			if *rawBuild.Building {
 				continue
 			}
 
@@ -128,7 +128,7 @@ func (c *Client) respRawToBuilds(raw *respRaw, removeBuildingBuilds bool) []*Bui
 					continue
 				}
 
-				if removeBuildingBuilds && *rawBuild.Building {
+				if *rawBuild.Building {
 					continue
 				}
 
@@ -146,7 +146,7 @@ func (c *Client) respRawToBuilds(raw *respRaw, removeBuildingBuilds bool) []*Bui
 	return res
 }
 
-func (c *Client) Builds(inProgressBuilds bool) ([]*Build, error) {
+func (c *Client) Builds() ([]*Build, error) {
 	// TODO: is it possible to retrieve only the element in actions with
 	// _class = "jenkins.metrics.impl.TimeInQueueAction" that contains the
 	// metrics?
@@ -162,7 +162,7 @@ func (c *Client) Builds(inProgressBuilds bool) ([]*Build, error) {
 		return nil, err
 	}
 
-	builds := c.respRawToBuilds(&resp, !inProgressBuilds)
+	builds := c.respRawToBuilds(&resp)
 
 	return builds, nil
 }

--- a/main.go
+++ b/main.go
@@ -206,7 +206,7 @@ func recordBuildStageJobInAllowList(b *jenkins.Build) bool {
 func fetchAndRecord(clt *jenkins.Client, store *store.Store, onlyRecordNewbuilds bool, metrics *jenkinsexporter.Metrics) error {
 	fetchStart := time.Now()
 
-	builds, err := clt.Builds(false)
+	builds, err := clt.Builds()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
```
print warning if status of a stage is in_progress

Because we only return builds from the jenkins clients if their building status
is false, it should not happen that a stage has an in_progress state.
If it happens anyways, log a warning.

-------------------------------------------------------------------------------
jenkins: remove unnecessary inProgressBuilds parameter of client

We always passed false as value, it is not needed to have a parameter for a
static value. Remove it.

-------------------------------------------------------------------------------
do not record runtime metrics for builds that are still running

To evaluate if a build is still running it is checked if build.Result is empty.
This is not sufficient, sometimes the result of a build is set but it is still
running. This causes that runtime metrics are recorded for builds that are still
in progress. The runtime metrics values are then too low.

To determine if a build is running fetch the building field of builds and
check if it is true instead.

```

Closes #20 