### PR TITLE
do not skip metric recording for older builds that are in progress

### DIFF
--- a/internal/jenkins/builds.go
+++ b/internal/jenkins/builds.go
@@ -119,10 +119,6 @@ func (c *Client) respRawToBuilds(raw *respRaw) []*Build {
 				continue
 			}
 
-			if *rawBuild.Building {
-				continue
-			}
-
 			b, err := c.buildRawToBuild(job.Name, "", rawBuild)
 			if err != nil {
 				c.logger.Printf("skipping build %s: %s", buildID(job, rawBuild), err)
@@ -136,10 +132,6 @@ func (c *Client) respRawToBuilds(raw *respRaw) []*Build {
 			for _, rawBuild := range multibranchJob.WorkflowJobBuilds {
 				if err := rawBuild.validate(); err != nil {
 					c.logger.Printf("skipping build %s: %s", multibranchBuildID(multibranchJob, job, rawBuild), err)
-					continue
-				}
-
-				if *rawBuild.Building {
 					continue
 				}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,33 +2,80 @@ package store
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 )
 
-type Store map[string]entry
+const version = 1
 
-type entry struct {
-	Value     int64
-	UpdatedAt time.Time
+var ErrIncompatibleFormat = errors.New("incompatible format")
+
+type Store struct {
+	Builds  map[string]*Build
+	Version uint64
 }
 
-func New() *Store {
-	return &Store{}
+type Build struct {
+	HighestRecordedBuildID int64
+	UnrecordedBuildIDs     map[int64]time.Time
+	UpdatedAt              time.Time
 }
 
-func (s *Store) Set(key string, val int64) {
-	(*s)[key] = entry{
-		Value:     val,
-		UpdatedAt: time.Now(),
+func (b *Build) SetHighestRecordedBuildID(v int64) {
+	b.HighestRecordedBuildID = v
+	b.UpdatedAt = time.Now()
+}
+
+func (b *Build) UnrecordedBuildIDsIsEmpty() bool {
+	return len(b.UnrecordedBuildIDs) == 0
+}
+
+func (b *Build) IsUnrecorded(id int64) bool {
+	_, exists := b.UnrecordedBuildIDs[id]
+	return exists
+}
+
+func (b *Build) DeleteUnrecorded(id int64) {
+	delete(b.UnrecordedBuildIDs, id)
+	b.UpdatedAt = time.Now()
+}
+
+func (b *Build) AddUnrecorded(id int64) (added bool) {
+	if b.IsUnrecorded(id) {
+		return false
+	}
+
+	b.UnrecordedBuildIDs[id] = time.Now()
+	b.UpdatedAt = time.Now()
+	return true
+}
+
+func newBuild(highestBuildID int64) *Build {
+	return &Build{
+		HighestRecordedBuildID: highestBuildID,
+		UnrecordedBuildIDs:     map[int64]time.Time{},
+		UpdatedAt:              time.Now(),
 	}
 }
 
-func (s *Store) Get(key string) (int64, bool) {
-	val, exist := (*s)[key]
-	return val.Value, exist
+func New() *Store {
+	return &Store{
+		Builds:  map[string]*Build{},
+		Version: version,
+	}
+}
+
+func (s *Store) NewBuild(key string, highestRecordedBuildID int64) *Build {
+	b := newBuild(highestRecordedBuildID)
+	s.Builds[key] = b
+	return b
+}
+
+func (s *Store) Get(key string) *Build {
+	return s.Builds[key]
 }
 
 func (s *Store) ToFile(path string) error {
@@ -40,7 +87,7 @@ func (s *Store) ToFile(path string) error {
 	dir := filepath.Dir(absPath)
 	err = os.MkdirAll(dir, 0755)
 	if err != nil {
-		return fmt.Errorf("can not create directory: '%s': %s", dir, err)
+		return fmt.Errorf("can not create directory: %q: %w", dir, err)
 	}
 
 	data, err := json.MarshalIndent(s, "", "  ")
@@ -63,17 +110,37 @@ func FromFile(path string) (*Store, error) {
 		return nil, err
 	}
 
+	if store.Version == 0 {
+		return nil, ErrIncompatibleFormat
+	}
+
 	return &store, nil
 }
 
-func (s *Store) RemoveOldEntries(age time.Duration) int {
+func (s *Store) RemoveOldBuilds(maxAge time.Duration) int {
 	now := time.Now()
 	var cnt int
 
-	for k, v := range *s {
-		if now.Sub(v.UpdatedAt) > age {
-			delete(*s, k)
+	for k, build := range s.Builds {
+		if now.Sub(build.UpdatedAt) > maxAge {
+			delete(s.Builds, k)
 			cnt++
+		}
+	}
+
+	return cnt
+}
+
+func (s *Store) RemoveOldUnrecordedEntries(maxAge time.Duration) int {
+	now := time.Now()
+	var cnt int
+
+	for _, build := range s.Builds {
+		for buildID, updatedAt := range build.UnrecordedBuildIDs {
+			if now.Sub(updatedAt) > maxAge {
+				delete(build.UnrecordedBuildIDs, buildID)
+				cnt++
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -354,6 +354,8 @@ func recordStagesMetric(metrics *jenkinsexporter.Metrics, b *jenkins.Build, stag
 		}
 
 		if *ignoreUnsuccessfulBuildStages && !strings.EqualFold(stage.Status, "SUCCESS") {
+			debugLogger.Printf("%s: skipping recording stage metrics for %q, stage status is: %q, requiring 'SUCCESS'",
+				b, stage.Name, stage.Status)
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -229,6 +229,10 @@ func fetchAndRecord(clt *jenkins.Client, stateStore *store.Store, onlyRecordNewb
 			continue
 		}
 
+		// TODO: remove all jobs from the stateStore that Jenkins did
+		// not return. These jobs must have been deleted, therefore
+		// their state does not need to be kept in memory and on disk.
+
 		// We can not pass job here because it's in the format
 		// <MultiBranchJobName>/<JobName>. The whitelist contains
 		// either the MultiBranchJobName or the JobName
@@ -242,6 +246,13 @@ func fetchAndRecord(clt *jenkins.Client, stateStore *store.Store, onlyRecordNewb
 		}
 
 		highestID := builds[0].ID
+
+		// TODO: remove all builds from the UnrecordedBuildIDsIsEmpty
+		// map that have a smaller ID then the lowest ID that jenkins
+		// returned for the build.
+		// This must mean that jenkins deleted the history of job with
+		// those IDs and will never return information about them that
+		// we can record.
 
 		storeBuild := stateStore.Get(job)
 		if storeBuild == nil {


### PR DESCRIPTION
When multiple builds run for the same job, it can happen that build N finishes before build N-1. If an unfinished build is retrieved it was ignored. If a build with a higher number already finished, it's build number is recorded as highest seen number and all previous builds are ignored.

This behavior caused that for a lot of builds no metrics were recorded which screws the statistics.

Instead of ignoring unfinished build if a newer one already finished, it's build number is now stored in a UnrecordedBuildIDs map.
If an following iteration the build finished and is in the UnrecordedBuildIDs maps, metrics for it are recorded and it is removed from the map.

This required to change the format of the state file. If a state file in the old format is found, jenkins-exporter will exit with an error.
To upgrade, the previous state file must either be deleted or a path to a different state file must be specified as parameter or via environment variable.

Closes #21 