### PR TITLE
Fix jenkins_exporter_errors{type=http_requests_total} + jenkins_http_requests_total metric mix up

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,16 @@ It provides the following Prometheus metrics:
 - Counter:
   - `jenkins_exporter_errors`  
     Counts the number of errors the jenkins-exporter encountered when fetching
-    informations from the Jenkins API.
+    information from the Jenkins API.
     - Labels:
       - type:
         - jenkins_api
         - jenkins_wfapi
-  - `jenkins_http_requests_total`  
-    Counts the number of http-requests sent successfully to Jenkins.
 
 By default job metrics are recorded for every finished Jenkins build. The
 Jenkins jobs for that builds are recorded can be limited with the
 `--jenkins-job-whitelist` command-line parameter.
-The duration types that are recorded can also be configured via a commandline
+The duration types that are recorded can also be configured via a command-line
 parameter.
 
 The exporter can also record durations of individual pipeline stages. This
@@ -82,7 +80,7 @@ make
 
 Then copy the jenkins-exporter into your `$PATH`.
 
-### As systemd Service ###
+### As Systemd Service ###
 
 1. Install `jenkins-exporter` to `/usr/local/bin`
 2. `cp dist/etc/default/jenkins-exporter /etc/default/`

--- a/internal/cli/buildstagemapflag.go
+++ b/internal/cli/buildstagemapflag.go
@@ -6,7 +6,7 @@ import "strings"
 // "<JOB-NAME>:<STAGE-NAME>,..."
 // into a map[JOB-NAME]map[STAGE-NAME]struct{} datastructure.
 // If an elem ends with a "," it is interpreted as being on the Job-Name.
-// Later elemens overwrite earlier elements.
+// Later element overwrite earlier elements.
 type BuildStageMapFlag map[string]map[string]struct{}
 
 func (b BuildStageMapFlag) Set(v string) error {

--- a/internal/jenkins/client.go
+++ b/internal/jenkins/client.go
@@ -99,7 +99,7 @@ func (c *Client) do(method, url string, result interface{}) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		_, _ = io.ReadAll(resp.Body)
+		_, _ = io.Copy(io.Discard, resp.Body)
 		return &ErrHTTPRequestFailed{Code: resp.StatusCode}
 	}
 

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ const (
 	appName = "jenkins-exporter"
 )
 
-// Version is set during compiliation via -ldflags.
+// Version is set during compilation via -ldflags.
 var Version = "unknown"
 
 const stateStoreCleanupInterval = 10 * 60 * time.Second

--- a/main.go
+++ b/main.go
@@ -515,7 +515,6 @@ func main() {
 		WithAuth(*jenkinsUsername, *jenkinsPassword).
 		WithLogger(debugLogger).
 		WithTimeout(*httpTimeout).
-		WithErrorMetrics(metrics.Errors).
 		WithRatelimit(*httpRequestRateEvery)
 
 	nextStateStoreCleanup := time.Now()


### PR DESCRIPTION
```
metrics: remove wrong jenkins_exporter_errors{type=http_requests_total} metric

The jenkins_http_requests_total and jenkins_exporter_errors metrics are mixed
up.
A metric called jenkins_exporter_errors with the label http_requests_total is
incremented for every http requests.
The name implied it only counts errors but this is not the case.
The documented metric called jenkins_http_requests_total is not recorded at all.

Remove jenkins_exporter_errors metrics with the http_requests_total label.
Remove mentions of the jenkins_http_requests_total metrics in the README.

If it turns out that there is a use case for the jenkins_http_requests_total
metric it can be added back.

-----------------------

http: do not use buffer when draining and discarding http body

Use io.Copy with io.Discard instead of io.ReadAll to drain the whole http body
when an error occurred.

This does not write the body unnecessary to a buffer in memory that will never
be used.
```